### PR TITLE
Replace jQuery url's HTTP to HTTPS

### DIFF
--- a/testFnc.html
+++ b/testFnc.html
@@ -13,7 +13,7 @@
 		}
 
 	</style>
-	<script type="text/javascript" src="http://code.jquery.com/jquery-latest.js"></script>
+	<script type="text/javascript" src="https://code.jquery.com/jquery-latest.js"></script>
 </head>
 <body>
 


### PR DESCRIPTION
Mixed Content: The page at 'https://rawgit.com/JJ81/column-count/master/testFnc.html' was loaded over HTTPS, but requested an insecure script 'http://code.jquery.com/jquery-latest.js'. This request has been blocked; the content must be served over HTTPS.

I close this problem, because rawgit service need HTTPS url for load jQuery.
And this is a link for demo: https://rawgit.com/JJ81/column-count/master/testFnc.html
